### PR TITLE
Added test support for V3 excel template

### DIFF
--- a/snp_haplotyper/excel_parser.py
+++ b/snp_haplotyper/excel_parser.py
@@ -213,6 +213,7 @@ def parse_excel_input(input_spreadsheet, snp_array_file=None):
             # Process cell locations in the format data_entry!$B$31 or data_entry!$F$22:$L$22 (merged cells)
             cell_location = dn.attr_text.split(":")[0].split("!")[1].replace("$", "")
             cell_value = str(data_entry_sheet[cell_location].value).strip()
+            # print(cell_location, cell_value)
             argument_dict[input_name] = cell_value
 
     biopsy_number = argument_dict["biopsy_number"]
@@ -355,6 +356,8 @@ def parse_excel_input(input_spreadsheet, snp_array_file=None):
         .replace("excel_test_Autosomal_Dominant_", "")
         .replace("excel_test_Autosomal_Recessive_", "")
         .replace("excel_test_X_linked_", "")
+        .replace("_v2", "")
+        .replace("_v3", "")
     )
 
     allowable_values = {
@@ -550,7 +553,7 @@ def parse_excel_input(input_spreadsheet, snp_array_file=None):
     args.gene_end = gene_end
     args.chr = chr
     args.flanking_region_size = flanking_region_size
-    args.consanguineous = True if consanguineous == "yes" else False
+    args.consanguineous = True if consanguineous.lower() == "yes" else False
 
     # If analysis is being done for embryos add that data as well
     if trio_only is False:

--- a/tests/functional/test_excel_import.py
+++ b/tests/functional/test_excel_import.py
@@ -51,7 +51,7 @@ def setup_test_data_from_excel(split_by_embryo=False, version=1):
     else:
         raise ValueError(f"Unsupported version: {version}")
 
-    excel_files = [f for f in os.listdir(excel_folder_path) if f.endswith(".xlsx")]
+    excel_files = [f for f in os.listdir(excel_folder_path) if f.endswith((".xlsx", ".xlsm"))]
 
     if version < 3:
         # remove the excel files that have XL in the name as they do not contain the data we need (reference_sex)
@@ -61,7 +61,11 @@ def setup_test_data_from_excel(split_by_embryo=False, version=1):
     # file paths for each run
     run_data_dict = {}
     for excel_file in excel_files:
-        run_name = re.sub(r"_v\d+\.xlsx$", "", excel_file.replace("excel_test_", "")).replace(".xlsx", "")
+        run_name = (
+            re.sub(r"_v\d+\.(xlsx|xlsm)$", "", excel_file.replace("excel_test_", ""))
+            .replace(".xlsx", "")
+            .replace(".xlsm", "")
+        )
         if split_by_embryo == False:
             run_data_dict[run_name] = Namespace(
                 input_spreadsheet=os.path.join(
@@ -102,7 +106,7 @@ def test_informative_snps_excel_v1(name, snp_validation_data):
     Raises:
     AssertionError: If the actual output does not match the expected output.
     """
-    test_args = setup_test_data_from_excel()
+    test_args = setup_test_data_from_excel(split_by_embryo=False, version=1)
     basher_input_namespace, error_dictionary, input_ok_flag = excel_parser_main(test_args[name])
 
     (
@@ -150,7 +154,7 @@ def test_informative_snps_excel_v2(name, snp_validation_data):
     Raises:
     AssertionError: If the actual output does not match the expected output.
     """
-    test_args = setup_test_data_from_excel()
+    test_args = setup_test_data_from_excel(split_by_embryo=False, version=2)
     basher_input_namespace, error_dictionary, input_ok_flag = excel_parser_main(test_args[name])
 
     (
@@ -198,7 +202,7 @@ def test_informative_snps_excel_v3(name, snp_validation_data):
     Raises:
     AssertionError: If the actual output does not match the expected output.
     """
-    test_args = setup_test_data_from_excel(False, version=3)
+    test_args = setup_test_data_from_excel(split_by_embryo=False, version=3)
     basher_input_namespace, error_dictionary, input_ok_flag = excel_parser_main(test_args[name])
 
     (
@@ -247,9 +251,9 @@ def test_embryo_categorization_excel_v1(name, embryo_validation_data):
     Raises:
     AssertionError: If the actual output does not match the expected output.
     """
-    test_args = setup_test_data_from_excel()
+    test_args = setup_test_data_from_excel(split_by_embryo=True, version=1)
     sample_id, embryo_id = name.rsplit("_", 1)
-    (basher_input_namespace, error_dictionary, input_ok_flag) = excel_parser_main(test_args[sample_id])
+    (basher_input_namespace, error_dictionary, input_ok_flag) = excel_parser_main(test_args[name])
 
     (
         mode_of_inheritance,
@@ -297,9 +301,9 @@ def test_embryo_categorization_excel_v2(name, embryo_validation_data):
     Raises:
     AssertionError: If the actual output does not match the expected output.
     """
-    test_args = setup_test_data_from_excel()
+    test_args = setup_test_data_from_excel(split_by_embryo=True, version=2)
     sample_id, embryo_id = name.rsplit("_", 1)
-    (basher_input_namespace, error_dictionary, input_ok_flag) = excel_parser_main(test_args[sample_id])
+    (basher_input_namespace, error_dictionary, input_ok_flag) = excel_parser_main(test_args[name])
 
     (
         mode_of_inheritance,
@@ -347,9 +351,9 @@ def test_embryo_categorization_excel_v3(name, embryo_validation_data):
     Raises:
     AssertionError: If the actual output does not match the expected output.
     """
-    test_args = setup_test_data_from_excel(True, version=3)
+    test_args = setup_test_data_from_excel(split_by_embryo=True, version=3)
     sample_id, embryo_id = name.rsplit("_", 1)
-    (basher_input_namespace, error_dictionary, input_ok_flag) = excel_parser_main(test_args[sample_id])
+    (basher_input_namespace, error_dictionary, input_ok_flag) = excel_parser_main(test_args[name])
 
     (
         mode_of_inheritance,


### PR DESCRIPTION
BASHer now supports the version 3 Excel Template which is required for consang AR cases and XL cases.  This required several small cahnges to how the test suite parses the excel filenames and automatically generates the tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/SNP_haplotyper/10)
<!-- Reviewable:end -->
